### PR TITLE
Removed permanent bottom scrollbar

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -8,7 +8,7 @@ html, body {
 
 .content {
   height: 100%;
-  overflow: scroll;
+  overflow: hidden scroll;
 }
 
 .panel-separator-distance{


### PR DESCRIPTION
The scrollbar was always displaying at the bottom of the view window, but that's unnecessary. Because the content is in a flex box, it should (hypothetically) never exceed the width of the view window. So I set the overflow on the x-axis to be hidden and the overflow on the y-axis to be a scrollbar.