### PR TITLE
Added Notifications API for #27 (NEEDS LOCALIZATION)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -77,5 +77,23 @@
   },
   "clear_notifications": {
     "message": "Clear notifications"
+  },
+  "show_notifications": {
+    "message": "Show browser notifications"
+  },
+  "description_notifications": {
+    "message": "Determines whether you will receive notification popups when new questions are found"
+  },
+  "notification_title_single": {
+    "message": "new question found!"
+  },
+  "notification_title_multiple": {
+    "message": "new questions found!"
+  },
+  "notification_message_more": {
+    "message": "more need help."
+  },
+  "notification_message_click": {
+    "message": "Click the SUMO Live Helper toolbar icon to view the question list..."
   }
 }

--- a/src/_locales/pt-BR/messages.json
+++ b/src/_locales/pt-BR/messages.json
@@ -77,5 +77,23 @@
   },
   "clear_notifications": {
     "message": "Limpar notificações"
+  },
+  "show_notifications": {
+    "message": "NEEDS MESSAGE"
+  },
+  "description_notifications": {
+    "message": "NEEDS MESSAGE"
+  },
+  "notification_title_single": {
+    "message": "NEEDS MESSAGE"
+  },
+  "notification_title_multiple": {
+    "message": "NEEDS MESSAGE"
+  },
+  "notification_message_more": {
+    "message": "NEEDS MESSAGE"
+  },
+  "notification_message_click": {
+    "message": "NEEDS MESSAGE"
   }
 }

--- a/src/html/preferences.html
+++ b/src/html/preferences.html
@@ -121,6 +121,11 @@
         <input class="btn input-settings" type="number" id="frequencySeekNewQuestions" name="frequencySeekNewQuestions" value="15" min="1" max="30">
         <small class="form-text text-muted small-frequency-distances" data-i18n="frequency_questions"></small>
     </div>
+	<div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" id="showNotifications">
+        <label class="custom-control-label" data-i18n="show_notifications" for="showNotifications"></label>
+        <small class="form-text text-muted" data-i18n="description_notifications"></small>
+    </div>
 </fieldset>
 <script src="../js/language.js"></script>
 <script src="../js/preferences.js"></script>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -53,6 +53,11 @@ questions.addEventListener('click', function(e) {
     }
 }, false);
 
+// API limitations prevent this
+/*browser.notifications.onClicked.addListener(function() {
+    browser.browserAction.openPopup();
+});*/
+
 // automatically refresh
 browser.alarms.create('checkSUMO',{delayInMinutes: parseInt(frequencySeekNewQuestions)}); // checks every X minutes
 browser.alarms.onAlarm.addListener(function(){
@@ -270,10 +275,34 @@ request.onload = function() {
         removeOld(responseSUMO.results);
         savedQuestions = newQuestionList.concat(savedQuestions);
         browser.storage.local.set({'questions':savedQuestions});
+        
+        if (localStorage.getItem("showNotifications") && newQuestionList.length > 0) {
+            showNotification(newQuestionList);
+        }
     
         toggleScreen();
         questionCount();
         load.style.display = 'none';
+}
+
+function showNotification(questions) {
+    var num = questions.length;
+    var title = num + ' ';
+    var message = '"' + questions[0].title + '"';
+    
+    if (num == 1) {
+        title += browser.i18n.getMessage("notification_title_single");
+    } else {
+        title += browser.i18n.getMessage("notification_title_multiple");
+        message += ' & ' + (num - 1) + ' ' + browser.i18n.getMessage("notification_message_more");
+    }
+    message += '\n\n' + browser.i18n.getMessage("notification_message_click");
+    browser.notifications.create({
+        "type": "basic",
+        "iconUrl": chrome.extension.getURL("/res/icons/icon-32.png"),
+        "title": title,
+        "message": message
+    });
 }
 
 // clears the notification and sets the title

--- a/src/js/preferences.js
+++ b/src/js/preferences.js
@@ -51,3 +51,17 @@ $(document).ready(function(){
     backgroundPage.request.onload();
     });
  });
+ 
+ // show or hide browser notifications
+$(document).ready(function(){
+    var checkbox = document.getElementById("showNotifications");
+    var val = localStorage.getItem('showNotifications');
+    if (val) {
+        checkbox.checked = val;
+    } else {
+        checkbox.checked = false;
+    }
+    $('#showNotifications').on('change', function(){
+        localStorage.setItem('showNotifications', $(this).val());
+    });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,6 +37,7 @@
     "tabs",
     "browserSettings",
     "activeTab",
-    "storage"
+    "storage",
+    "notifications"
   ]
 }


### PR DESCRIPTION
The Notifications API will display a browser notification when a new question is found. It currently defaults to off. The English localization is there, but need the Portuguese to be added based on the English strings. This closes bug #27 