### PR TITLE
English default language to search for new opened questions

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -129,7 +129,7 @@ function loaded(data) {
     }
 
     if (typeof data.chooseLanguage === 'undefined' || data.chooseLanguage === null){
-        locale = navigator.language;
+        locale = "en-US";
         browser.storage.local.set({chooseLanguage: locale});
     } else {
         locale = data.chooseLanguage;

--- a/src/js/preferences.js
+++ b/src/js/preferences.js
@@ -18,7 +18,7 @@ function loadSettings(data) {
     if (typeof data.chooseLanguage !== 'undefined' && data.chooseLanguage !== null) {
         language.value = data.chooseLanguage;
     } else {
-        language.value = navigator.language;
+        language.value = "en-US";
     }
     
     // load check frequency


### PR DESCRIPTION
I downloaded Firefox in French and did a test with the PR #44, the language field at preferences page appears empty and the search for new opened questions uses the browser language. This PR define the English as the default language to search for opened questions.