### PR TITLE
Replaced "Settings" with "Preferences"

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Preferences"
   },
-  "settings": {
-    "message": "Settings"
-  },
   "one_question_without_answer": {
     "message": " question without answer (Click to open)"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Preferences"
   },
-  "settings": {
-    "message": "Settings"
-  },
   "one_question_without_answer": {
     "message": " question without answer (Click to open)"
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Preferences"
   },
-  "settings": {
-    "message": "Settings"
-  },
   "one_question_without_answer": {
     "message": " question without answer (Click to open)"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Préférences"
   },
-  "settings": {
-    "message": "Paramètres"
-  },
   "one_question_without_answer": {
     "message": " question sans réponse (Cliquer pour ouvrir)"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Preferences"
   },
-  "settings": {
-    "message": "Settings"
-  },
   "one_question_without_answer": {
     "message": " question without answer (Click to open)"
   },

--- a/src/_locales/pt-BR/messages.json
+++ b/src/_locales/pt-BR/messages.json
@@ -21,9 +21,6 @@
   "preferences": {
     "message": "Preferências"
   },
-  "settings": {
-    "message": "Configurações"
-  },
   "one_question_without_answer": {
     "message": " questão sem resposta (Clique para abrir)"
   },

--- a/src/html/preferences.html
+++ b/src/html/preferences.html
@@ -25,7 +25,7 @@
 <body class="col-md-12 padding-body">
 <fieldset class="padding-fieldset">
     <div>
-        <h4><strong id="settings" data-i18n="settings"></strong></h4>
+        <h4><strong id="settings" data-i18n="preferences"></strong></h4>
     </div>
     <br>
     <div class="custom-control custom-checkbox">


### PR DESCRIPTION
Instead of having "Settings" and "Preferences", we can just call it "Preferences". This will make it more consistent and be 1 less string that we need to localize (#68).