### PR TITLE
Fix #108 word wrapping

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -131,6 +131,8 @@ label > select {
 #items li div {
     flex-grow: 1;
     padding: 8px;
+    word-break: normal;
+    overflow-wrap: anywhere;
 }
 
 #items li div:first-child,


### PR DESCRIPTION
The question title was overflowing when there was a long word (or string) in it and should now be fixed with `word-break` and `overflow-wrap`.