### PR TITLE
Fixed issue #133

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -66,13 +66,9 @@ function settingsUpdated(changes, area) {
  * Toggle browserAction button between sidebar and popup
  */
 function toggleSidebarPreference() {
-    if (onlySidebar && !isMobile) {
+    if (onlySidebar || isMobile) {
         browser.browserAction.setPopup({
             popup: ''
-        });
-    } else if (isMobile) {
-        browser.browserAction.setPopup({
-            popup: '/html/popup.html?view=mobile'
         });
     } else {
         browser.browserAction.setPopup({
@@ -87,6 +83,10 @@ function toggleSidebarPreference() {
 function openWindow() {
     if (onlySidebar) {
         browser.sidebarAction.open();
+    } else if (isMobile) {
+        browser.tabs.create({
+            url: '/html/popup.html?view=mobile'
+        });
     } else {
         browser.browserAction.openPopup();
     }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -221,6 +221,7 @@ function createQuestionUI(product, title, id, locale, isNew) {
     button.className = 'button button-icon primary';
     button.id = id;
     button.href = url;
+    button.setAttribute('target', '_blank');
     buttonIcon.className = 'pf-open-in-new';
     button.appendChild(buttonIcon);
     buttonContainer.appendChild(button);


### PR DESCRIPTION
This pull request fixes issue #133.

The reason the tab kept closing is that it was still treated like a browserAction on desktop, so it closed when it was no longer focused. To fix that, I made the mobile menu option open the question list in a new tab instead of a browserAction tab.