### PR TITLE
Can select multiple languages to monitor (issue #61)

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -138,8 +138,27 @@ label > * {
     flex-grow: 0;
 }
 
+#items li div:first-of-type {
+    position: relative;
+}
+
 .item__icon {
     width: 32px;
+}
+
+.one-locale .item__locale {
+    display: none !important;
+}
+
+.item__locale {
+    position: absolute;
+    bottom: 5px;
+    right: 0;
+    font-size: .7rem;
+    background: var(--blue-60);
+    padding: 2px 5px;
+    color: white;
+    border-radius: 100000px;
 }
 
 .item--unread {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -155,10 +155,58 @@ label > * {
     bottom: 5px;
     right: 0;
     font-size: .7rem;
-    background: var(--blue-60);
     padding: 2px 5px;
-    color: white;
     border-radius: 100000px;
+}
+
+.item__locale.cs {
+    background: var(--purple-50);
+    color: white;
+}
+
+.item__locale.en-US {
+    background: var(--blue-60);
+    color: white;
+}
+
+.item__locale.es {
+    background: var(--green-70);
+    color: white;
+}
+
+.item__locale.fi {
+    background: var(--red-70);
+    color: white;
+}
+
+.item__locale.hu {
+    background: var(--orange-60);
+    color: white;
+}
+
+.item__locale.id {
+    background: var(--teal-50);
+    color: black;
+}
+
+.item__locale.pt-BR {
+    background: var(--yellow-50);
+    color: black;
+}
+
+.item__locale.sl {
+    background: var(--magenta-70);
+    color: white;
+}
+
+.item__locale.sr {
+    background: var(--grey-50);
+    color: white;
+}
+
+.item__locale.st {
+    background: #000;
+    color: white;
 }
 
 .item--unread {

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -63,6 +63,7 @@
         <li class="template question-template">
             <div>
                 <img src="../res/products/{PRODUCT}.png" title="{PRODUCT}" class="item__icon">
+                <span class="item__locale"></span>
             </div>
             <div class="item__title">{TITLE}</div>
             <div>

--- a/src/html/preferences.html
+++ b/src/html/preferences.html
@@ -82,21 +82,38 @@
             </label>
             
             <h3 data-i18n="language"></h3>
-            <label for="chooseLanguage">
+            <p>
                 <span data-i18n="choose_language_description"></span>
-                <!-- Use style width to temporarily fix text overflow -->
-                <select id="chooseLanguage" name="chooseLanguage" style="width: 200px">
-                    <option value="cs">Čeština</option>
-                    <option value="en-US" selected>English</option>
-                    <option value="es">Español</option>
-                    <!--<option value="fi">suomi</option>-->
-                    <option value="hu">Magyar</option>
-                    <!--<option value="id">Bahasa Indonesia</option>-->
-                    <option value="pt-BR">Português (do Brasil)</option>
-                    <!--<option value="sl">slovenščina</option>-->
-                    <!--<option value="sr">Српски</option>-->
-                    <!--<option value="st">Sesotho</option>-->
-                </select>
+            </p>
+            <label for="cs">
+                <input id="cs" name="chooseLanguage" type="checkbox" value="cs"> Čeština
+            </label>
+            <label for="en-US">
+                <input id="en-US" name="chooseLanguage" type="checkbox" value="en-US"> English
+            </label>
+            <label for="es">
+                <input id="es" name="chooseLanguage" type="checkbox" value="es"> Español
+            </label>
+            <label for="fi">
+                <input id="fi" name="chooseLanguage" type="checkbox" value="fi"> Suomi
+            </label>
+            <label for="hu">
+                <input id="hu" name="chooseLanguage" type="checkbox" value="hu"> Magyar
+            </label>
+            <label for="id">
+                <input id="id" name="chooseLanguage" type="checkbox" value="id"> Bahasa Indonesia
+            </label>
+            <label for="pt-BR">
+                <input id="pt-BR" name="chooseLanguage" type="checkbox" value="pt-BR"> Português (do Brasil)
+            </label>
+            <label for="sl">
+                <input id="sl" name="chooseLanguage" type="checkbox" value="sl"> Slovenščina
+            </label>
+            <label for="sr">
+                <input id="sr" name="chooseLanguage" type="checkbox" value="sr"> Српски
+            </label>
+            <label for="st">
+                <input id="st" name="chooseLanguage" type="checkbox" value="st"> Sesotho
             </label>
 
             <h3 data-i18n="theme"></h3>

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -233,6 +233,7 @@ function createQuestionUI(product, title, id, locale, isNew) {
 
     // Add question locale
     productLocale.textContent = locale.substring(0, 2).toUpperCase();
+    productLocale.classList.add(locale);
 
     // Add question title
     questionTitle.textContent = title;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -109,6 +109,9 @@ function handleMessage(message) {
             questionList = [];
             addQuestions([], true);
             return;
+        case 'toggle_locale_labels':
+            showLocaleLabels(message.multiple);
+            return;
     }
 }
 
@@ -118,6 +121,7 @@ function handleMessage(message) {
  */
 function dataLoaded(data) {
     setCurrentTheme(data.chooseTheme);
+    showLocaleLabels(data.chooseLanguage.length != 1);
     
     questionList = data.questions;
 
@@ -126,7 +130,7 @@ function dataLoaded(data) {
             questionList[i].product.toLowerCase(),
             questionList[i].title,
             questionList[i].id,
-            data.chooseLanguage,
+            questionList[i].locale,
             questionList[i].new
         );
     }
@@ -210,6 +214,7 @@ function createQuestionUI(product, title, id, locale, isNew) {
     let list = document.getElementById('items');
     let item = questionTemplate.cloneNode(true);
     let productIcon = item.getElementsByClassName('item__icon')[0];
+    let productLocale = item.getElementsByClassName('item__locale')[0];
     let questionTitle = item.getElementsByClassName('item__title')[0];
     let button = item.getElementsByClassName('item__link')[0];
     let url = 'https://support.mozilla.org/' + locale + '/questions/' + id;
@@ -225,6 +230,9 @@ function createQuestionUI(product, title, id, locale, isNew) {
     // Add question icon
     productIcon.src = '../res/products/' + product + '.png';
     productIcon.title = browser.i18n.getMessage('product_' + product);
+
+    // Add question locale
+    productLocale.textContent = locale.substring(0, 2).toUpperCase();
 
     // Add question title
     questionTitle.textContent = title;
@@ -265,6 +273,15 @@ function toggleQuestionList() {
         questionListUI.style.display = 'none';
         empty.style.display = 'block';
     }
+}
+
+/**
+ * Show/Hide locale labels on question list
+ * @param {boolean} show 
+ */
+function showLocaleLabels(show) {
+    if (show) questionListUI.classList.remove('one-locale');
+    else questionListUI.classList.add('one-locale');
 }
 
 /**

--- a/src/js/preferences.js
+++ b/src/js/preferences.js
@@ -56,10 +56,6 @@ function handleMessage(message) {
  */
 function loadSettings(data) {
     setCurrentTheme(data.chooseTheme);
-    
-    if (data.chooseLanguage) {
-        document.settings.chooseLanguage.value = data.chooseLanguage;
-    }
 
     if (data.frequencySeekNewQuestions) {
         document.settings.frequencySeekNewQuestions.value = data.frequencySeekNewQuestions;
@@ -81,6 +77,13 @@ function loadSettings(data) {
     } else {
         document.settings.chooseProduct[i].checked = true;
     }
+
+    if (data.chooseLanguage) {
+        let languages = data.chooseLanguage;
+        for (i = 0; i < languages.length; i++) {
+            document.getElementById(languages[i]).checked = true;
+        }
+    }
     
     if (data.chooseTheme) {
         document.settings.chooseTheme.value = data.chooseTheme;
@@ -97,8 +100,8 @@ function saveChange(element) {
     let preference;
     let preferenceObject = {};
 
-    if (element.target.name == 'chooseProduct') {
-        preference = getProductList();
+    if (element.target.name == 'chooseProduct' || element.target.name == 'chooseLanguage') {
+        preference = getList(element.target.name);
     } else if (element.target.type == 'checkbox') {
         preference = element.target.checked;
     } else {
@@ -110,15 +113,15 @@ function saveChange(element) {
 }
 
 /**
- * Generate list of products to watch
+ * Generate preference array
  * @return {Array.<string>}
  */
-function getProductList() {
+function getList(option) {
     let preference = [];
 
-    for (i = 0; i < document.settings.chooseProduct.length; i++) {
-        if (document.settings.chooseProduct[i].checked) {
-            preference.push(document.settings.chooseProduct[i].value);
+    for (i = 0; i < document.settings[option].length; i++) {
+        if (document.settings[option][i].checked) {
+            preference.push(document.settings[option][i].value);
         }
     }
 


### PR DESCRIPTION
This pull request allows users to select and monitor questions from multiple languages (resolves #61). Many contributors on SUMO answer questions from multiple languages, so this feature will be beneficial to them, as it makes it easier to see questions from different locales.

Additionally, I added a locale badge next to each question so that the users can easily see what language each question was posted to. This badge only displays if the user has more than one language selected, since it's not a necessary feature if the user is only watching one language.

**SOME MINOR LOCALIZATION CHANGES MAY BE REQUIRED IN THE PREFERENCES UI**

This pull request also adds and enables all of the locales that are currently supported on SUMO, regardless of whether or not the extension is localized for that language.