### PR TITLE
Permanently store questions for 24 hours

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -124,18 +124,8 @@ function dataLoaded(data) {
     showLocaleLabels(data.chooseLanguage.length != 1);
     
     questionList = data.questions;
-
-    for (i = 0; i < questionList.length; i++) {
-        createQuestionUI(
-            questionList[i].product.toLowerCase(),
-            questionList[i].title,
-            questionList[i].id,
-            questionList[i].locale,
-            questionList[i].new
-        );
-    }
-
-    toggleQuestionList();
+    addQuestions(questionList, false);
+    
     document.getElementById('page-loader').style.display = 'none';
     callAPI();
 }
@@ -186,13 +176,15 @@ function callAPI(event) {
  */
 function addQuestions(questions, isFinishedLoading) {
     for (i = 0; i < questions.length; i++) {
-        createQuestionUI(
-            questions[i].product,
-            questions[i].title,
-            questions[i].id,
-            questions[i].locale,
-            true
-        );
+        if (document.getElementsByClassName('item--' + questions[i].id)[0] == undefined && questions[i].show) {
+            createQuestionUI(
+                questions[i].product,
+                questions[i].title,
+                questions[i].id,
+                questions[i].locale,
+                questions[i].new
+            );
+        }
     }
 
     toggleQuestionList();
@@ -315,7 +307,7 @@ async function markAllAsRead(event) {
  */
 function removeQuestion(id) {
     let question = document.getElementsByClassName('item--' + id)[0];
-    question.parentElement.removeChild(question);
+    if (question) question.parentElement.removeChild(question);
 }
 
 /**


### PR DESCRIPTION
Questions are now stored in the Storage API for 24 hours, regardless of whether or not they are answered, unless the user deselects watching that product. This closes #153.

A few new properties have been added to each question stored in the Storage API:
* `created`: Stores the timestamp for when the question was posted.
* `show`: Determines whether or not the question should appear on the user's question list.

Additionally, I implemented a question list storage version in the Storage API to help handle storage format changes in the future. Questions that are missing the new attributes would cause errors, so the add-on will automatically purge the question list from the Storage API and rebuild it.