### PR TITLE
Added ability to open links in new tab (issue #172)

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Zobrazovat oznámení prohlížeče"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Určujte, zda chcete dostávat oznámení při nalezení nového dotazu"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Show browser notifications"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Determines whether you will receive notification popups when new questions are found"
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Mostrar notificaciones en el navegador"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Determinar si recibiras notificaciones cuando se encuentren nuevas preguntas"
     },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Voir les notifications dans le navigateur"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Détermine si vous recevez des notifications de type popups lorsque de nouvelles questions sont trouvées"
     },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Böngészőértesítések megjelenítése"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Meghatározza, hogy kap-e felugró értesíteseket, ha új kérdések vannak"
     },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Wyświetl powiadomienia"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Określa, czy po znalezieniu nowych pytań będziesz otrzymywać powiadomienia w postaci wyskakujących okienek."
     },

--- a/src/_locales/pt-BR/messages.json
+++ b/src/_locales/pt-BR/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Mostrar notificações no navegador"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Determina se você receberá popups de notificação quando novas questões forem encontradas"
     },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -75,6 +75,9 @@
     "show_notifications": {
         "message": "Visa webbläsar notifikationer"
     },
+    "open_in_new_tab": {
+        "message": "Open questions in new tab"
+    },
     "description_notifications": {
         "message": "Bestämmer om du kommer få notifikations popups när nya frågor har hittats eller inte"
     },

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -212,6 +212,10 @@ label > * {
     color: white;
 }
 
+.item__link * {
+    pointer-events: none;
+}
+
 .item--unread {
     font-weight: bold;
 }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -67,7 +67,7 @@
             </div>
             <div class="item__title">{TITLE}</div>
             <div>
-                <a class="button button-icon primary item__link" href="{URL}" target="_blank">
+                <a class="button button-icon primary item__link" href="{URL}">
                     <span class="pf-open-in-new"></span>
                 </a>
             </div>

--- a/src/html/preferences.html
+++ b/src/html/preferences.html
@@ -51,6 +51,10 @@
                 <input id="showNotifications" type="checkbox" name="showNotifications">
                 <span data-i18n="show_notifications"></span>
             </label>
+            <label for="openNewTab">
+                <input id="openNewTab" type="checkbox" name="openNewTab">
+                <span data-i18n="open_in_new_tab"></span>
+            </label>
 
             <h3 data-i18n="products"></h3>
             <p>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -2,6 +2,7 @@
 let frequencySeekNewQuestions, 
     locale, 
     showNotifications, 
+    openNewTab,
     onlySidebar, 
     product,
     theme,
@@ -46,6 +47,13 @@ function settingsUpdated(changes, area) {
                 return;
             case 'showNotifications':
                 showNotifications = changes[item].newValue;
+                return;
+            case 'openNewTab':
+                openNewTab = changes[item].newValue;
+                browser.runtime.sendMessage({
+                    task: 'update_open_in_new_tab',
+                    value: openNewTab
+                });
                 return;
             case 'chooseProduct':
                 product = changes[item].newValue;
@@ -199,6 +207,16 @@ function dataLoaded(data) {
         });
     } else {
         showNotifications = data.showNotifications;
+    }
+
+    // Load open in new tab setting
+    if (typeof data.openNewTab === 'undefined' || data.openNewTab === null) {
+        openNewTab = true;
+        browser.storage.local.set({
+            openNewTab: openNewTab
+        });
+    } else {
+        openNewTab = data.openNewTab;
     }
 
     // Load product watch list

--- a/src/js/preferences.js
+++ b/src/js/preferences.js
@@ -65,6 +65,10 @@ function loadSettings(data) {
         document.settings.showNotifications.checked = data.showNotifications;
     }
 
+    if (data.openNewTab) {
+        document.settings.openNewTab.checked = data.openNewTab;
+    }
+
     if (data.onlySidebar) {
         document.settings.onlySidebar.checked = data.onlySidebar;
     }


### PR DESCRIPTION
This pull request adds a new setting called "Open questions in new tab" that will allow the user to select whether they want the question to open in the current tab or a new tab. The setting defaults to `true`, so users will see no change to the current behaviour when the update is installed.

This PR closes #172.

**The setting needs to be localized**