### PR TITLE
Prevent blank new tab from opening

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -69,7 +69,9 @@ function openSidebar(event) {
 async function openQuestion(question) {
     question.preventDefault();
     question.stopPropagation();
+
     const url = question.target.href;
+    if (!url) return;
     let tabID = await browser.tabs.query({ active: true });
     tabID = tabID[0].id;
 


### PR DESCRIPTION
Added a check in the `openQuestion()` function that aborts opening a question if the element that is does not have a URL attached to it (meaning it's not a question button). This fixes #175.