### PR TITLE
Fixed loading wheel not disappearing on first install (#174)

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -144,7 +144,7 @@ function dataLoaded(data) {
 
     addQuestions(questionList, false);
     
-    document.getElementById('page-loader').style.display = 'none';
+    showLoadingWheel(false);
     callAPI();
 }
 
@@ -207,6 +207,7 @@ function addQuestions(questions, isFinishedLoading) {
 
     if (isFinishedLoading) {
         showLoadingBar(false);
+        showLoadingWheel(false);
     }
 }
 
@@ -360,5 +361,13 @@ function showLoadingBar(state) {
         load.style.opacity = '1';
     } else {
         load.style.opacity = '0';
+    }
+}
+
+function showLoadingWheel(state) {
+    const load = document.getElementById('page-loader');
+
+    if (!state) {
+        load.style.display = 'none';
     }
 }


### PR DESCRIPTION
This pull request stops the loading wheel from being displayed on the popup window after the user first installs the add-on. This issue was previously reproducible if the user opened the popup before the first API call was completed. This closes #174.