### PR TITLE
Fixes the issue with API requests for Firefox and Thunderbird products

### DIFF
--- a/src/html/preferences.html
+++ b/src/html/preferences.html
@@ -67,7 +67,7 @@
                 <span data-i18n="choose_product_description"></span>
             </p>
             <label for="firefox" class="checkbox">
-                <input id="firefox" name="chooseProduct" type="checkbox" value="Firefox">
+                <input id="firefox" name="chooseProduct" type="checkbox" value="firefox">
                 <span data-i18n="product_firefox"></span>
             </label>
             <label for="firefox-enterprise" class="checkbox">
@@ -95,7 +95,7 @@
                 <span data-i18n="product_hubs"></span>
             </label>
             <label for="thunderbird" class="checkbox">
-                <input id="thunderbird" name="chooseProduct" type="checkbox" value="Thunderbird">
+                <input id="thunderbird" name="chooseProduct" type="checkbox" value="thunderbird">
                 <span data-i18n="product_thunderbird"></span>
             </label>
             


### PR DESCRIPTION
### Requirement for Contributing a Pull Request

* [x] Put an X between the brackets on this line if you have done all of the 
      following:
    * You agree to license your code under the project's open source license 
      (MPL 2.0).
    * Your branch is based off the current master.
    * You did not include merge commits in pull requests; include only commits 
      with the new relevant code.

### Identify the Bug

Issue #198 

### Description of the Change

Now, "Firefox" and "Thunderbird" are sent to the API in lower camel case. Previously, all the languages were being sent in upper camel case, which resulted in no response for those products.

### Alternate Designs

No

### Possible Drawbacks

No







Before fix (Hungarian):

![before_fix](https://github.com/mozillabrasil/sumo_live_helper/assets/8497721/210dbd28-f522-41cf-af21-572b90b24d71)

After fix (Hungarian):

![after_fix](https://github.com/mozillabrasil/sumo_live_helper/assets/8497721/ccb45f6a-ca15-4c56-b45c-948bb2a9f18b)

Before fix (English):

![before_fix(en)](https://github.com/mozillabrasil/sumo_live_helper/assets/8497721/cd7f30eb-4854-4a77-905c-e6ff6c675db4)

After fix (English):

![after_fix(en)](https://github.com/mozillabrasil/sumo_live_helper/assets/8497721/2d35d4e2-1963-4f87-8045-51f088a42e25)
 