### PR TITLE
Fix web-ext linting warnings

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -567,7 +567,7 @@ function showNotification(questions) {
 
     browser.notifications.create({
         type: 'basic',
-        iconUrl: chrome.extension.getURL('/res/products/' + questions[0].product + '.png'),
+        iconUrl: browser.runtime.getURL('/res/products/' + questions[0].product + '.png'),
         title: title,
         message: message
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,9 +6,9 @@
     "homepage_url": "https://github.com/mozillabrasil/sumo_live_helper",
     "default_locale": "en",
     "author": "Mozilla Brasil, Jhonatas Machado, Wesley Branton, Danny Colin",
-    "applications": {
+    "browser_specific_settings": {
         "gecko": {
-            "strict_min_version": "62.0",
+            "strict_min_version": "79.0",
             "id": "sumo_live_helper@mozillabr.org"
         }
     },


### PR DESCRIPTION
### Requirement for Contributing a Pull Request

* [x] Put an X between the brackets on this line if you have done all of the 
      following:
    * You agree to license your code under the project's open source license 
      (MPL 2.0).
    * Your branch is based off the current master.
    * You did not include merge commits in pull requests; include only commits 
      with the new relevant code.

### Identify the Bug

`web-ext lint` was returning a few warnings about APIs deprecated and/or not available in the minimum android version in our manifest.json.

### Description of the Change

I updated the manifest.json and the deprecated API used in background.js.